### PR TITLE
Changed default deployment date

### DIFF
--- a/Sources/Web/App/Homepage/DeployDialog.js
+++ b/Sources/Web/App/Homepage/DeployDialog.js
@@ -7,6 +7,8 @@ import Select from "../Shared/Select";
 
 var DeployDialog = React.createClass({
   getInitialState: function () {
+    var tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
     return {
       loading: true,
       scheduled: false,
@@ -15,7 +17,7 @@ var DeployDialog = React.createClass({
       version:null,
       tasks: [],
       chosenTasks: [],
-      date: new Date()
+      date: tomorrow
     };
   },
 


### PR DESCRIPTION
Considering that if the date is not changed, the deployment happens instantly I think it's the case to set the default date to tomorrow.

This way, you have one day to eventually remove the deployment.